### PR TITLE
Add colour to Sphinx output

### DIFF
--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade -r requirements.txt
 
       - name: Build docs
-        run: python -bb -X dev -W error -m sphinx -n -E -a -W --keep-going docs build
+        run: python -bb -X dev -W error -m sphinx --color -n -E -a -W --keep-going docs build
 
       - name: Check links
-        run: python -b -X dev -m sphinx -b linkcheck -W --keep-going docs build
+        run: python -b -X dev -m sphinx --color -b linkcheck -W --keep-going docs build


### PR DESCRIPTION
Updates PR https://github.com/python/docs-community/pull/30.

The GitHub Actions runner isn't a tty so colour needs to be turned on.

Sphinx makes good use of colour, making it easier to find problems in the output, especially for the linkcheck.

# Test run

https://github.com/hugovk/docs-community/actions/runs/1878087526 